### PR TITLE
Update success signature.

### DIFF
--- a/dropzone/dropzone.d.ts
+++ b/dropzone/dropzone.d.ts
@@ -96,7 +96,7 @@ interface DropzoneOptions {
 	sending?(file:DropzoneFile, xhr:XMLHttpRequest, formData:{}):void;
 	sendingmultiple?(files:DropzoneFile[], xhr:XMLHttpRequest, formData:{}):void;
 
-	success?(file:DropzoneFile, responseText:string):void;
+	success?(file: DropzoneFile, response: Object|string): void;
 	successmultiple?(files:DropzoneFile[], responseText:string):void;
 
 	canceled?(file:DropzoneFile):void;


### PR DESCRIPTION
The success method can return either a json object or a string object in dropzone 4.0.1. Dropzone checks the type and if it's application/json it automatically converts it to json.
